### PR TITLE
Start of join_network option for scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ This section describes the config.json as currently specified.  The section is a
 - **`scripts.environment`**: JSON object describing the general environment in which the script will run.
 - **`scripts.environment.image`**: Docker image of the container in which the script will run.  This does not need to be the same as the image of the service.
 - **`scripts.environment.interactive`**: When set to true, your Docker container is ran in interactive mode and can thus receive input from the user.  Non-interactive scripts are easier to call by external scripts.
+- **`scripts.environment.join_networks`**: For scripts which run in a project, this will make the script container join the default network.  Set to `true` to activate this option.
 - **`scripts.environment.script`**: The script which will be ran.  Make sure this script is executable (`chmod a+x your-script.sh`).  If the script can be ran by your container as a script, it's fine.  You could use a shebang like `#!/usr/bin/ruby` as the first line of your script to run a ruby script, or you could have a standard shell script which launches something totally different.
 - **`scripts.mounts.app`**: For scripts which run in a project, this is the place where the full project folder will be mounted.  It allows you to do things like create new files for the project.
 - **`scripts.mounts.service`**: For scripts which run from a template, this is the place where the service file will be mounted.  It allows you to do things like create new files for the service.

--- a/mu
+++ b/mu
@@ -360,15 +360,31 @@ then
         arguments="${@:4}"
         echo -n "."
         image_name=`echo "$command_spec" | $interactive_cli $jq_command_get_image`
-        echo ""
+        echo -n "."
+        # NOTE: this approach for discovering the project name will
+        # not work when running installation scripts for a service
+        docker_compose_project_name=`docker inspect --format '{{ index .Config.Labels "com.docker.compose.project"}}' $container_id`
+        echo -n "."
         interactive_mode=`echo "$command_spec" | $interactive_cli jq -r '.environment.interactive // false'`
+        echo -n "."
         it=""
-        if [[ true = "$interactive_mode" ]];
+        if [[ true == "$interactive_mode" ]];
         then
             it=" -it "
         fi
+        echo -n "."
 
-        docker run --volume $PWD:$app_mount_point --volume /tmp/mu/cache/$container_id/scripts/$folder_name:/script $it -w $working_directory --rm --entrypoint ./$entry_point $image_name $arguments
+        network_options=$()
+        join_networks=`echo "$command_spec" | $interactive_cli jq -r '.environment.join_networks // false'`
+        echo -n "."
+        if [[ true == "$join_networks" ]]
+        then
+            default_network_id=`docker network ls -f "label=com.docker.compose.project=$docker_compose_project_name" -f "label=com.docker.compose.network=default" -q`
+            network_options=("--network" "$default_network_id")
+        fi
+        echo -n "."
+
+        docker run ${network_options[@]} --volume $PWD:$app_mount_point --volume /tmp/mu/cache/$container_id/scripts/$folder_name:/script $it -w $working_directory --rm --entrypoint ./$entry_point $image_name $arguments
     elif [[ -f "Dockerfile" ]]
     then
         # A script for developing a microservice


### PR DESCRIPTION
Adds an implementation of the join_networks option for scripts.  With this option set, the script will join the default network of the container.  The name is currently bound to `join_networks` because this feature could extend with users optionally specifying the networks to join.

This could be considered an initial implementation of #4.