### PR TITLE
Add Docker Compose V2 compatibility

### DIFF
--- a/mu
+++ b/mu
@@ -16,6 +16,15 @@ function status_step() {
 }
 
 ####
+## Redirect Docker Compose V1 to Compose V2 if needed
+####
+if ! [command -v docker-compose >/dev/null 2>&1 ]; then
+    function docker-compose() {
+        docker compose --compatibility $@;
+    }
+fi
+
+####
 ## Implementation
 ####
 


### PR DESCRIPTION
## Context

* mu-cli use `docker-compose` in many places. 
* `docker-compose` (Compose V1) will be deprecated in June 2023. cf. https://docs.docker.com/compose/compose-v2/

## Proposal

When Compose V1 is missing redirect to Compose V2 
```
if ! [command -v docker-compose >/dev/null 2>&1 ]; then
    function docker-compose() {
        docker compose --compatibility $@;
    }
fi
```
