### PR TITLE
use docker v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Let's first see which commands the migrations service offers.  The description o
 
 We can list the commands to execute with the -h option.
 
-    docker-compose up -d
+    docker compose up -d
 
     mu script migrations -h
 
@@ -90,7 +90,7 @@ You can develop scripts to add to your project, and you can develop them live by
 
 Make sure you `up` your stack again so the scripts are picked up when running the `mu` command:
 
-    docker-compose up -d
+    docker compose up -d
 
 #### Adding the metadata for our command
 
@@ -159,7 +159,7 @@ In your docker-compose.yml, make sure your service has the right volume attached
         volumes:
           /path/to/scripts/:/app/scripts
 
-Make sure the service is created by running `docker-compose up -d` (optionally followed by `docker-compose stop`) and ensure you don't remove the `mine` container when running scripts (containers which are not created, will not be used for finding scripts).
+Make sure the service is created by running `docker compose up -d` (optionally followed by `docker compose stop`) and ensure you don't remove the `mine` container when running scripts (containers which are not created, will not be used for finding scripts).
 
 Add the `config.json` in the `/path/to/scripts/` folder.
 
@@ -207,7 +207,7 @@ A common and sensible name for the container containing your project specific sc
 
 Before executing scripts, make sure the container has been created.  You should `up` the service.  The container should exit after a few seconds to preserve system resources, it's inner contents will stay available to simple-script-store.
 
-    docker-compose up -d project-scripts
+    docker compose up -d project-scripts
 
 Add the `config.json` script to the `./config/project-scripts/` folder of your mu-project.  Script files are best nested in folders beneath this folder, we suggest not to further nest scripts to keep them easy to find.
 

--- a/mu
+++ b/mu
@@ -53,7 +53,7 @@ function ensure_mu_cli_docker() {
 ####
 function confirm_existing_service() {
     service=$1
-    available_container_id=`docker-compose $(print_source_docker_files) ps -q $service`
+    available_container_id=`docker compose $(print_source_docker_files) ps -a -q $service`
     if [[ $? -ne 0 ]]; then
         echo "Service $service not found"
         return 1;
@@ -62,7 +62,7 @@ function confirm_existing_service() {
         echo "Container for $service does not exist yet.  May we create a container for $service without starting it?"
         read -p "Create container? [Y/n]: " -n 1 -s -r INPUT
         case ${INPUT:-Y} in
-            [Yy]*) `docker-compose $(print_source_docker_files) up --no-start $service >> /dev/null`;;
+            [Yy]*) `docker compose $(print_source_docker_files) up --no-start $service >> /dev/null`;;
             [Nn]*) echo "NOT creating container"; return 1 ;;
         esac
     else
@@ -97,7 +97,7 @@ function print_service_documentation() {
     if confirm_existing_service $service
     then
         service=$1
-        available_container_id=`docker-compose $(print_source_docker_files) ps -q $service`
+        available_container_id=`docker compose $(print_source_docker_files) ps -a -q $service`
         mkdir -p /tmp/mu/cache/$available_container_id
         docker cp $available_container_id:/app/scripts /tmp/mu/cache/$available_container_id 2> /dev/null
         local_cat_command="cat /tmp/mu/cache/$available_container_id/scripts/config.json"
@@ -155,7 +155,7 @@ function print_available_services_information() {
     jq_documentation_get_description="jq -r .documentation.description"
     jq_documentation_get_arguments="jq -r .documentation.arguments[]"
     echo "...looking for containers..."
-    available_services=`docker-compose $(print_source_docker_files) ps --services`
+    available_services=`docker compose $(print_source_docker_files) ps -a --services`
     echo ""
     echo "found services:"
     for available_service in $available_services
@@ -358,7 +358,7 @@ then
         # get hold of the container that defines the script
         confirm_existing_service $service
         service_exists=$?
-        container_id=`docker-compose $(print_source_docker_files) ps -q $service`
+        container_id=`docker compose $(print_source_docker_files) ps -a -q $service`
         if [[ $? -ne 0 ]] ; # the service doesn't exist in the docker-compose
         then
             echo ""

--- a/mu
+++ b/mu
@@ -170,14 +170,14 @@ then
     echo "Launching mu.semte.ch project ..."
     if [[ "dev" == $2 ]]
     then
-        docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d
+        docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d
     else
-        docker-compose -f docker-compose.yml up -d
+        docker compose -f docker-compose.yml up -d
     fi
 elif [[ "logs" == $1 ]]
 then
     arguments="${@:2}"
-    docker-compose `print_source_docker_files` logs -f $arguments
+    docker compose `print_source_docker_files` logs -f $arguments
 elif [[ "project" == $1 ]]
 then
     if [[ "new" == $2 ]]

--- a/mu
+++ b/mu
@@ -155,7 +155,7 @@ function print_available_services_information() {
     jq_documentation_get_description="jq -r .documentation.description"
     jq_documentation_get_arguments="jq -r .documentation.arguments[]"
     echo "...looking for containers..."
-    available_services=`docker compose $(print_source_docker_files) ps -a --services`
+    available_services=`docker compose $(print_source_docker_files) config --services`
     echo ""
     echo "found services:"
     for available_service in $available_services

--- a/mu
+++ b/mu
@@ -89,7 +89,16 @@ function print_commands_documentation() {
 }
 
 function print_source_docker_files() {
-    echo `ls docker-compose*.yml | tac | awk '{ print "-f " $1 }' | tr '\n' ' '`
+    # NOTE: This is used to create the -f options for docker compose.
+    # If a user has specified DOCKER_COMPOSE_FILE (such as through bash
+    # script automatically picking up the .dev.yml), then we emit an
+    # empty string to let docker use its default processing.
+    if [[ -z "$DOCKER_COMPOSE_FILE" ]]
+    then
+        echo ""
+    else
+        echo `ls docker-compose*.yml | tac | awk '{ print "-f " $1 }' | tr '\n' ' '`
+    fi
 }
 
 function print_service_documentation() {


### PR DESCRIPTION
since docker-compose is deprecated, updated the script to using `docker compose` (instead of `docker-compose`) command. Since this command doesn't print stopped containers by default, added `-a` switch to all `docker compose ps` commands as a safety measure.

This is a breaking change as it will not work for users on the (deprecated) docker v1