### PR TITLE
Remove -service from service name on generation

### DIFF
--- a/mu
+++ b/mu
@@ -719,8 +719,6 @@ then
             echo ""
             echo "  $DOCKER_SERVICE_NAME:"
             echo "    image: semtech/mu-javascript-template:1.8.0"
-            echo "    links:"
-            echo "      - db:database"
             echo "    ports:"
             echo '      - "8888:80"'
             echo '      - "9229:9229"'
@@ -757,8 +755,6 @@ then
             echo ""
             echo "  $DOCKER_SERVICE_NAME:"
             echo "    image: semtech/mu-python-template:2.0.0-beta.1"
-            echo "    links:"
-            echo "      - db:database"
             echo "    ports:"
             echo '      - "8888:80"'
             echo "    environment:"

--- a/mu
+++ b/mu
@@ -676,7 +676,7 @@ then
             git commit -m "Initializing new mu ruby service"
             echo "You can add the following snippet in your pipeline"
             echo "to hack this service live."
-            DOCKER_SERVICE_NAME=`echo $SERVICE_NAME | sed -e s/-//g`
+            DOCKER_SERVICE_NAME=`echo $SERVICE_NAME | sed -e s/-service$//`
             echo ""
             echo "  $DOCKER_SERVICE_NAME:"
             echo "    image: semtech/mu-ruby-template:3.1.0"
@@ -715,7 +715,7 @@ then
             git commit -m "Initializing new mu javascript service"
             echo "You can add the following snippet in your pipeline"
             echo "to hack this service live."
-            DOCKER_SERVICE_NAME=`echo $SERVICE_NAME | sed -e s/-//g`
+            DOCKER_SERVICE_NAME=`echo $SERVICE_NAME | sed -e s/-service$//`
             echo ""
             echo "  $DOCKER_SERVICE_NAME:"
             echo "    image: semtech/mu-javascript-template:1.8.0"
@@ -751,7 +751,7 @@ then
             git commit -m "Initializing new mu python service"
             echo "You can add the following snippet in your pipeline"
             echo "to hack this service live."
-            DOCKER_SERVICE_NAME=`echo $SERVICE_NAME | sed -e s/-//g`
+            DOCKER_SERVICE_NAME=`echo $SERVICE_NAME | sed -e s/-service$//`
             echo ""
             echo "  $DOCKER_SERVICE_NAME:"
             echo "    image: semtech/mu-python-template:2.0.0-beta.1"


### PR DESCRIPTION
When a new service is generated, its name should ideally end in -service.  The docker-compose should not include -service in the naming.  This alters the suggestion given to start developing a newly generated service.