### PR TITLE
Allow arguments to be supplied to dev and prod start scripts

### DIFF
--- a/mu
+++ b/mu
@@ -719,8 +719,6 @@ then
             echo ""
             echo "  $DOCKER_SERVICE_NAME:"
             echo "    image: semtech/mu-javascript-template:1.8.0"
-            echo "    links:"
-            echo "      - db:database"
             echo "    ports:"
             echo '      - "8888:80"'
             echo '      - "9229:9229"'
@@ -757,8 +755,6 @@ then
             echo ""
             echo "  $DOCKER_SERVICE_NAME:"
             echo "    image: semtech/mu-python-template:2.0.0-beta.1"
-            echo "    links:"
-            echo "      - db:database"
             echo "    ports:"
             echo '      - "8888:80"'
             echo "    environment:"

--- a/mu
+++ b/mu
@@ -176,12 +176,16 @@ function print_available_services_information() {
 
 if [[ "start" == $1 ]]
 then
-    echo "Launching mu.semte.ch project ..."
     if [[ "dev" == $2 ]]
     then
-        docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d
+        echo "Launching mu.semte.ch project for development ..."
+        docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d "${@:3}"
+    elif [[ "prod" == $2 ]]
+    then
+        echo "Launching mu.semte.ch project for production ..."
+        docker compose -f docker-compose.yml up -d "${@:3}"
     else
-        docker compose -f docker-compose.yml up -d
+        echo "Second argument should be one of [dev, prod]."
     fi
 elif [[ "logs" == $1 ]]
 then


### PR DESCRIPTION
Splits up launching of dev and prod.  When either is launched, multiple arguments can be supplied to the start script allowing to override some of the defaults.  Neither of these currently takes the (optional) docker-compose.override.yml into account yet.