### PR TITLE
Fix/arm

### DIFF
--- a/.woodpecker/feature.yml
+++ b/.woodpecker/feature.yml
@@ -2,6 +2,7 @@ steps:
   build-and-push:
     image: woodpeckerci/plugin-docker-buildx
     settings:
+      platforms: linux/amd64,linux/arm64
       repo: "${CI_REPO_OWNER##mu-}/${CI_REPO_NAME%%-service}"
       tags: "feature-${CI_COMMIT_BRANCH##feature/}"
       username:

--- a/.woodpecker/latest.yml
+++ b/.woodpecker/latest.yml
@@ -2,6 +2,7 @@ steps:
   build-and-push:
     image: woodpeckerci/plugin-docker-buildx
     settings:
+      platforms: linux/amd64,linux/arm64
       repo: "${CI_REPO_OWNER##mu-}/${CI_REPO_NAME%%-service}"
       tags: latest
       username:

--- a/.woodpecker/release.yml
+++ b/.woodpecker/release.yml
@@ -2,6 +2,7 @@ steps:
   release:
     image: woodpeckerci/plugin-docker-buildx
     settings:
+      platforms: linux/amd64,linux/arm64
       repo: "${CI_REPO_OWNER##mu-}/${CI_REPO_NAME%%-service}"
       tags: "${CI_COMMIT_TAG##v}"
       username:

--- a/completions
+++ b/completions
@@ -3,7 +3,7 @@
 # Useful info found at http://www.linuxjournal.com/content/more-using-bash-complete-command
 
 MU_CLI_VERSION="1.0.3"
-sh -c "docker run --rm --volume /tmp:/tmp semtech/mu-cli:${MU_CLI_VERSION} bash ensure-files.sh &"
+sh -c "docker run --platform linux/amd64 --rm --volume /tmp:/tmp semtech/mu-cli:${MU_CLI_VERSION} bash ensure-files.sh &"
 
 # I use variables that start with retval to indicate that they are only used to
 # populate the return value for the function whose name is the second part of the

--- a/mu
+++ b/mu
@@ -31,7 +31,7 @@ function ensure_mu_cli_docker() {
 
     if [[ -z $container_hash ]] ;
     then
-        docker run --volume /tmp:/tmp -i --name mucli --rm --entrypoint "tail" -d semtech/mu-cli:$MU_CLI_VERSION -f /dev/null
+        docker run --platform linux/amd64--volume /tmp:/tmp -i --name mucli --rm --entrypoint "tail" -d semtech/mu-cli:$MU_CLI_VERSION -f /dev/null
         if [[ "$?" -ne "0" ]]
         then
             echo "I could not start the mu-cli container.  Aborting operation." >> /dev/stderr

--- a/mu
+++ b/mu
@@ -31,7 +31,7 @@ function ensure_mu_cli_docker() {
 
     if [[ -z $container_hash ]] ;
     then
-        docker run --platform linux/amd64--volume /tmp:/tmp -i --name mucli --rm --entrypoint "tail" -d semtech/mu-cli:$MU_CLI_VERSION -f /dev/null
+        docker run --platform linux/amd64 --volume /tmp:/tmp -i --name mucli --rm --entrypoint "tail" -d semtech/mu-cli:$MU_CLI_VERSION -f /dev/null
         if [[ "$?" -ne "0" ]]
         then
             echo "I could not start the mu-cli container.  Aborting operation." >> /dev/stderr


### PR DESCRIPTION
On an ARM machine, I always received an error when using mu-cli.
For example:
```
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
```

This PR adds the platform flag so it does not stop with an error and makes sure that Woodpecker builds to ARM for the future.